### PR TITLE
Ignore local .vincent workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ tmp/
 # IDEs
 .vscode/
 .idea/
+.vincent/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- add the .vincent tooling directory to .gitignore so editor state stays local
