### PR TITLE
Relocate VGGT weights into models directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PYTHON := python
 UV := uv
 
 RUNTIME_DIRS := logs outputs tmp data
-MODEL_FILES := models repo/vggt/vggt_model.pt
+MODEL_FILES := models/vggt_model.pt repo/vggt/vggt_model.pt
 
 help: ## Show this help message
 	@echo "$(BLUE)VGGT-MPS Development Commands$(NC)"

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ python -c "import torch; print(torch.backends.mps.is_available())"
 
 ```bash
 # Verify model file
-ls -lh repo/vggt/vggt_model.pt
+ls -lh models/vggt_model.pt
 # Should show ~5GB file
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -211,7 +211,7 @@ python -c "import torch; print(torch.backends.mps.is_available())"
 
 ```bash
 # Verify model file
-ls -lh repo/vggt/vggt_model.pt
+ls -lh models/vggt_model.pt
 # Should show ~5GB file
 ```
 

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -1,62 +1,87 @@
 #!/usr/bin/env python3
-"""
-Download VGGT model weights from Hugging Face
-"""
+"""Download VGGT model weights from Hugging Face."""
 
 import os
-import requests
+import shutil
 from pathlib import Path
+
+import requests
 
 try:
     from tqdm import tqdm
 except ImportError:
     tqdm = None  # type: ignore
 
-def download_file(url, dest_path):
-    """Download file with progress bar"""
+MODEL_DIR = Path("models")
+LEGACY_MODEL_PATH = Path("repo/vggt/vggt_model.pt")
+MODEL_PATH = MODEL_DIR / "vggt_model.pt"
+
+
+def download_file(url: str, dest_path: Path) -> None:
+    """Download file with progress bar."""
     if tqdm is None:
         raise RuntimeError("tqdm is required; install it or run this script as __main__")
 
     response = requests.get(url, stream=True)
-    total_size = int(response.headers.get('content-length', 0))
+    total_size = int(response.headers.get("content-length", 0))
 
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(dest_path, 'wb') as file:
-        with tqdm(total=total_size, unit='B', unit_scale=True, desc=dest_path.name) as pbar:
+    with open(dest_path, "wb") as file:
+        with tqdm(total=total_size, unit="B", unit_scale=True, desc=dest_path.name) as pbar:
             for chunk in response.iter_content(chunk_size=8192):
                 file.write(chunk)
                 pbar.update(len(chunk))
 
-def main():
+
+def migrate_legacy_model() -> Path:
+    """Move legacy model file into the models/ directory if needed."""
+    if MODEL_PATH.exists():
+        return MODEL_PATH
+
+    if LEGACY_MODEL_PATH.exists():
+        MODEL_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            LEGACY_MODEL_PATH.replace(MODEL_PATH)
+        except OSError:
+            shutil.copy2(LEGACY_MODEL_PATH, MODEL_PATH)
+            LEGACY_MODEL_PATH.unlink(missing_ok=True)
+        print(f"🔁 Migrated model weights to {MODEL_PATH}")
+        return MODEL_PATH
+
+    return MODEL_PATH
+
+
+def main() -> None:
     print("=" * 60)
     print("VGGT Model Downloader")
     print("=" * 60)
 
     model_url = "https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
-    model_path = Path("repo/vggt/vggt_model.pt")
+    model_path = migrate_legacy_model()
 
     if model_path.exists():
         print(f"✅ Model already exists at {model_path}")
         print(f"   Size: {model_path.stat().st_size / 1e9:.2f} GB")
         response = input("\nRedownload? (y/N): ")
-        if response.lower() != 'y':
+        if response.lower() != "y":
             print("Skipping download.")
             return
 
-    print(f"\n📥 Downloading VGGT model (5GB)...")
+    print("\n📥 Downloading VGGT model (5GB)...")
     print(f"From: {model_url}")
     print(f"To: {model_path}")
 
     try:
         download_file(model_url, model_path)
-        print(f"\n✅ Successfully downloaded model!")
+        print("\n✅ Successfully downloaded model!")
         print(f"   Size: {model_path.stat().st_size / 1e9:.2f} GB")
-    except Exception as e:
-        print(f"\n❌ Download failed: {e}")
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"\n❌ Download failed: {exc}")
         print("\nYou can manually download from:")
         print(model_url)
-        print(f"And place it at: {model_path}")
+        print(f"and place it at: {model_path}")
+
 
 if __name__ == "__main__":
     if tqdm is None:

--- a/tests/test_vggt_mps.py
+++ b/tests/test_vggt_mps.py
@@ -8,6 +8,10 @@ import numpy as np
 from pathlib import Path
 import sys
 
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from vggt_mps.config import get_model_path
+
 print("=" * 50)
 print("VGGT on Apple Silicon (MPS) Test")
 print("=" * 50)
@@ -27,7 +31,7 @@ print("-" * 50)
 # Try to load the model
 try:
     print("Loading VGGT model weights...")
-    model_path = Path("repo/vggt/vggt_model.pt")
+    model_path = get_model_path()
 
     if model_path.exists():
         print(f"✅ Model file found: {model_path}")


### PR DESCRIPTION
## Summary
- move the default checkpoint location from repo/vggt/vggt_model.pt into a top-level models/ folder
- migrate existing downloads automatically and update config/get_model_path()
- refresh docs, tests, and examples to look in the canonical path